### PR TITLE
Update 02-install-openfl.html.md

### DIFF
--- a/documentation/00_getting_started/02-install-openfl.html.md
+++ b/documentation/00_getting_started/02-install-openfl.html.md
@@ -21,3 +21,9 @@ lime setup blackberry
 ```
 
 For more information on OpenFL, head on over to [OpenFL.org](http://www.openfl.org/developer/documentation/).
+
+## Mac OS Troubleshooting
+
+* Make sure you have `Command Line Tools for Xcode` installed and **updated** to your OSX version. You can download it here: [Download For Apple Developers](https://developer.apple.com/downloads/).
+
+* Lime setup requires root permission: `sudo lime setup android`.


### PR DESCRIPTION
- Added Mac OS Troubleshooting

Just updated my Mac to latest OSX. Without `Command Line Tools` UPDATED it will just throw some crazy errors when compiling a demo. Trying to setup Android without `sudo` throws some crazy errors too.
