### PR TITLE
Updated recent API changes

### DIFF
--- a/documentation/03_resources/01-cheat-sheet.html.md
+++ b/documentation/03_resources/01-cheat-sheet.html.md
@@ -90,7 +90,7 @@ import flixel.util.FlxColor;
 myText = new FlxText(0, 0, 500); // x, y, width
 myText.text = "Hello World";
 myText.setFormat("assets/font.ttf", 20, FlxColor.WHITE, "center");
-myText.setBorderStyle(FlxText.BORDER_OUTLINE, FlxColor.RED, 1);
+myText.setBorderStyle(FlxTextBorderStyle.OUTLINE, FlxColor.RED, 1);
 ```
 
 
@@ -516,8 +516,8 @@ add(canvas);
 The last argument of `makeGraphic()` is `Unique`, whether the graphic should be an unique instance in the graphics cache, if you create multiple graphics like this, set it to `true` to avoid conflicts.
 
 ```haxe
-var lineStyle:LineStyle = { color: FlxColor.RED, thickness: 1 };
-var fillStyle:FillStyle = { color: FlxColor.RED, alpha: 0.5 };
+var lineStyle = { color: FlxColor.RED, thickness: 1 };
+var fillStyle = { color: FlxColor.RED, alpha: 0.5 };
 ```
 
 ```haxe


### PR DESCRIPTION
- FlxText.BORDER_OUTLINE is now FlxTextBorderStyle.OUTLINE
- LineStyle and FillStyle don't exist anymore, became anonymous objects

I believe these changes aren't published on haxelib, what to do? I will forget to update these changes later...
