### PR TITLE
Fixed code snippet

### DIFF
--- a/documentation/01_tutorial/07-6-loading-the-tilemap.html.md
+++ b/documentation/01_tutorial/07-6-loading-the-tilemap.html.md
@@ -40,8 +40,8 @@ One of the great things about using Ogmo with HaxeFlixel is that there is alread
 	
 	```haxe
 	_map = new FlxOgmoLoader(AssetPaths.room_001__oel);
-	_mWalls.follow();
 	_mWalls = _map.loadTilemap(AssetPaths.tiles__png, 16, 16, "walls");
+	_mWalls.follow();
 	_mWalls.setTileProperties(1, FlxObject.NONE);
 	_mWalls.setTileProperties(2, FlxObject.ANY);
 	add(_mWalls);


### PR DESCRIPTION
_mWalls.follow() was placed above the loadTilemap function. As _mWalls was not set, an error would occur.