### PR TITLE
Fix broken link to flixel commands

### DIFF
--- a/documentation/00_getting_started/01-install-haxeflixel.html.md
+++ b/documentation/00_getting_started/01-install-haxeflixel.html.md
@@ -35,7 +35,7 @@ haxelib upgrade
 
 ## Install flixel command
 
-Run the following command to be able to use [flixel commands](https://github.com/HaxeFlixel/flixel-docs/blob/master/documentation/04_community/13-flixel-tools.html.md#commands):
+Run the following command to be able to use [flixel commands](http://haxeflixel.com/documentation/flixel-tools/):
 	
 ``` bash
 haxelib install flixel-tools


### PR DESCRIPTION
There's no anchor on the page, otherwise I would've used one.  But at least it's the right page, not a github 404 :)