### PR TITLE
Fix Typo in Second Sentence

### DIFF
--- a/documentation/00_getting_started/01-install-haxeflixel.html.md
+++ b/documentation/00_getting_started/01-install-haxeflixel.html.md
@@ -3,7 +3,7 @@ title: "Install HaxeFlixel"
 ```
 
 HaxeFlixel requires a system with a working installation of OpenFL and Haxe. 
-If you havent set this up previously please follow the 
+If you haven't set this up previously please follow the 
 [official install guide](http://www.openfl.org/documentation/setup/) and return here.
 
 To install the latest stable version of HaxeFlixel you can use [haxelib](http://lib.haxe.org/) 


### PR DESCRIPTION
Added a missing apostrophe to the contraction *haven't* in the second sentence. No other typos were found on this page.