### PR TITLE
Include the HaxeFlixel Discord server in the community page

### DIFF
--- a/documentation/04_community/00-community.html.md
+++ b/documentation/04_community/00-community.html.md
@@ -13,6 +13,7 @@ There is a multitude of channels to interact with the community:
 - The [HaxeFlixel organization](http://github.com/haxeflixel) on GitHub
 - The [HaxeFlixel page](http://www.indiedb.com/engines/haxeflixel) on IndieDB
 - Join our development chat on [Slack](https://haxeflixel.slack.com/)<sup>[1]</sup>
+- [HaxeFlixel server](https://discord.gg/0uEuWH3spjck73Lo) on Discord
 - [HaxeFlixel group](http://steamcommunity.com/groups/haxeflixel) on Steam
 
 


### PR DESCRIPTION
We're an active, welcoming, and friendly community on Discord. The HF Discord channel isn't just a clone of the Slack server. It's less formal, and we're happy to talk about game development in general. We're not limited to discussions about the engine. It's also a place to show your project and get feedback. I think it complements the Slack server rather nicely so it would be a nice addition to the community.