### PR TITLE
Fix Gamepad sample code

### DIFF
--- a/documentation/02_handbook/18-gamepads.html.md
+++ b/documentation/02_handbook/18-gamepads.html.md
@@ -32,7 +32,7 @@ class PlayState extends FlxState
         super.update(elapsed);
 
         // Important: can be null if there's no active gamepad yet!
-        gamepad = FlxG.gamepads.lastActive;
+        var gamepad:FlxGamepad = FlxG.gamepads.lastActive;
         if (gamepad != null)
         {
             updateGamepadInput(gamepad);


### PR DESCRIPTION
This updates the example code for the gamepad to properly initialize the `gamepad` variable. Without the `var` keyword and type, the game will fail to compile due to these errors:

```
source/PlayState.hx:12: characters 8-15 : Unknown identifier : gamepad
source/PlayState.hx:13: characters 12-19 : Unknown identifier : gamepad
```