### PR TITLE
Fix the Community - Code Contributions headers

### DIFF
--- a/documentation/04_community/07-code-contributions.html.md
+++ b/documentation/04_community/07-code-contributions.html.md
@@ -4,7 +4,7 @@ title: "Code Contributions"
 
 Contributing code to HaxeFlixel is done all through the official git repositories on [GitHub](http://www.github.com/haxeflixel).
 
-###Use the Dev branches
+### Use the Dev Branches
 
 All repositories except the [website](https://github.com/HaxeFlixel/haxeflixel.com) and [documentation](https://github.com/HaxeFlixel/flixel-docs) use a `dev` branch which is the main entry point for features and bugfixes to accepted into the codebase. When the code is tested by the community it is then merged into master and released on haxelib.
 
@@ -12,7 +12,7 @@ To clarify: the `dev` branch on [flixel-addons](https://github.com/HaxeFlixel/fl
 
 If you are making changes to the codebase that could include breaking changes or a new API, we make use of the pull request feature and suggest developers use a feature branch model. [Feature branches](https://www.atlassian.com/git/workflows#!workflow-feature-branch) are simply new branches with your code that are named with a title relating to your code.
 
-###Merge Approval
+### Merge Approval
 
 Before a major feature is merged into core our general workflow is to get approval from a [core-contributor](https://github.com/orgs/HaxeFlixel/people) with push access.
 
@@ -22,7 +22,7 @@ Developers do have limited time so keep in mind some simple steps to get your pu
 - Conduct as much testing as possible on the supported targets of HaxeFlixel. If the code is for a specific target only make a clear note for developers to test.
 - Provide a link to a working, compilable demo of your code.
 
-###Contribute to the stack
+### Contribute to the Stack
 
 Everything about the technology stack of HaxeFlixel is open-source so you can contribute directly to the language, compiler and upstream libraries:
 
@@ -37,4 +37,3 @@ Everything about the technology stack of HaxeFlixel is open-source so you can co
 - The website [haxeflixel.com](https://github.com/HaxeFlixel/haxeflixel.com)
 
 If you are wanting to contribute code, please review the [code style](http://haxeflixel.com/documentation/code-style) and [code-contributions](http://haxeflixel.com/documentation/code-contributions) pages.
-


### PR DESCRIPTION
This commit adds spaces between the `#` characters and actual header text so that they render as proper Markdown. I also made all of the titles in this page title-case for consistency.