### PR TITLE
Fix Game Mechanic Explorer links

### DIFF
--- a/documentation/03_resources/07-faq.html.md
+++ b/documentation/03_resources/07-faq.html.md
@@ -15,7 +15,7 @@ No, HaxeFlixel abstracts it completely.
 
 - [@SeiferTim's](https://twitter.com/SeiferTim) [Dungeon Crawler Tutorial](http://haxeflixel.com/documentation/tutorials/)
 
-- [Kasoki's](https://github.com/atomicptr/GameMechanicExplorer-HaxeFlixel) [Game Mechanic Explorer port](http://gme.qr9.de/)
+- [atomicptr's](https://github.com/atomicptr/GameMechanicExplorer-HaxeFlixel) [Game Mechanic Explorer port](http://gme.qr9.de/)
 
 - [Videos from Christopher Butler](https://www.youtube.com/watch?v=LpKvSPwHOP8&list=PLi0ypjD5PcV9xdjycW0hYi_HD297012tE)
 (covering everything from installation to prototyping a platformer).

--- a/documentation/03_resources/07-faq.html.md
+++ b/documentation/03_resources/07-faq.html.md
@@ -15,7 +15,7 @@ No, HaxeFlixel abstracts it completely.
 
 - [@SeiferTim's](https://twitter.com/SeiferTim) [Dungeon Crawler Tutorial](http://haxeflixel.com/documentation/tutorials/)
 
-- [Kasoki's](https://github.com/kasoki/GameMechanicExplorer-HaxeFlixel) [Game Mechanic Explorer port](http://gme.kasoki.de/)
+- [Kasoki's](https://github.com/atomicptr/GameMechanicExplorer-HaxeFlixel) [Game Mechanic Explorer port](http://gme.qr9.de/)
 
 - [Videos from Christopher Butler](https://www.youtube.com/watch?v=LpKvSPwHOP8&list=PLi0ypjD5PcV9xdjycW0hYi_HD297012tE)
 (covering everything from installation to prototyping a platformer).


### PR DESCRIPTION
This updates the repository and website link for the Game Mechanic Explorer. The repo URL and website URL have both changed. See https://github.com/atomicptr/GameMechanicExplorer-HaxeFlixel/pull/18 for more info about the website domain change.