### PR TITLE
Fixed the link to the 'using' article

### DIFF
--- a/documentation/03_resources/01-cheat-sheet.html.md
+++ b/documentation/03_resources/01-cheat-sheet.html.md
@@ -478,7 +478,7 @@ super.update(elapsed);
 using flixel.util.FlxSpriteUtil;
 ```
 
-Haxe docs about the `using` keyword: [haxe.org/manual/using](http://haxe.org/manual/using).
+Haxe docs about the `using` keyword: [haxe.org/manual/lf-static-extension.html](https://haxe.org/manual/lf-static-extension.html).
 
 ```haxe
 var canvas = new FlxSprite();


### PR DESCRIPTION
the old link (https://haxe.org/manual/using) lead to a 404