### PR TITLE
Updated the link to the AS3/Haxe differences page

### DIFF
--- a/documentation/02_handbook/00-haxeflixel-handbook.html.md
+++ b/documentation/02_handbook/00-haxeflixel-handbook.html.md
@@ -6,7 +6,7 @@ rootDoc: true
 Welcome to the HaxeFlixel handbook. These pages are intended to answer common questions and explain the main ideas and structures behind most HaxeFlixel games.
 As the types of games and use cases of HaxeFlixel are vast we appreciate developers making additions and improvements to this documentation through [GitHub](https://github.com/HaxeFlixel/flixel-docs).
 
-If you are familiar with AS3 and new to Haxe, we encourage you to read the [AS3 and Haxe comparison](http://www.openfl.org/archive/developer/documentation/actionscript-developers/).
+If you are familiar with AS3 and new to Haxe, we encourage you to read the [AS3 and Haxe comparison](http://books.openfl.org/as3-conversion-guide/comparing-haxe-and-actionscript/overview.html).
 
 HaxeFlixel's API is largely the same as the AS3 version, and existing documentation and resources for ActionScript 3 are still relevant.
 The biggest changes in the API were made in HaxeFlixel 3.x you can review the changes on the [HaxeFlixel 3.x page.](/documentation/haxeflixel-3-x)

--- a/documentation/02_handbook/06-flxsave.html.md
+++ b/documentation/02_handbook/06-flxsave.html.md
@@ -22,7 +22,7 @@ _gameSave = new FlxSave(); // initialize
 _gameSave.bind("SaveDemo"); // bind to the named save slot
 ```
 
-Note the string "SaveDemo". This is how HaxeFlixel tracks what save slot you are binding to in local storage. If you want to have multiple saves, you will probably want to define a series of strings to identify each slot, eg. "SaveSlot1", "SaveSlot2", etc. and bind to the appropriate one. For more information on using multiple save slots, take a look at [Wolfgang's article](https://web.archive.org/web/20150116114005/http://www.funstormgames.com/blog/2012/01/flixel-advanced-saving-tips-tricks/) on the subject for AS3 Flixel, but keep in mind that [the AS3 syntax is a little different from Haxe](http://www.openfl.org/archive/developer/documentation/actionscript-developers/).
+Note the string "SaveDemo". This is how HaxeFlixel tracks what save slot you are binding to in local storage. If you want to have multiple saves, you will probably want to define a series of strings to identify each slot, eg. "SaveSlot1", "SaveSlot2", etc. and bind to the appropriate one. For more information on using multiple save slots, take a look at [Wolfgang's article](https://web.archive.org/web/20150116114005/http://www.funstormgames.com/blog/2012/01/flixel-advanced-saving-tips-tricks/) on the subject for AS3 Flixel, but keep in mind that [the AS3 syntax is a little different from Haxe](http://books.openfl.org/as3-conversion-guide/comparing-haxe-and-actionscript/overview.html).
 
 Note: If you plan to use `FlxG.save` you can skip the initializing and binding steps, as HaxeFlixel has done it for you.
 


### PR DESCRIPTION
They've updated their docs, now the AS3/Haxe differences page is in the wikibook: http://books.openfl.org/as3-conversion-guide/