### PR TITLE
Minor fix of entity loading snippet for Tiled

### DIFF
--- a/documentation/01_tutorial/07-6-loading-the-tilemap.html.md
+++ b/documentation/01_tutorial/07-6-loading-the-tilemap.html.md
@@ -84,7 +84,7 @@ One of the great things about using Ogmo with HaxeFlixel is that there is alread
 	var tmpMap:TiledObjectLayer = cast _map.getLayer("entities");
 	for (e in tmpMap.objects)
 	{
-		placeEntities(e.type, e.xmlData.x);
+		placeEntities(e.name, e.xmlData.x);
 	}
 	```
 


### PR DESCRIPTION
Fixed a minor bug, where entity type was passed as argument instead of entity name, so the object wasn't placed at desired coordinates.