### PR TITLE
Change the variables seePlayer and playerPosition

### DIFF
--- a/documentation/01_tutorial/10-9-enemies-and-basic-ai.html.md
+++ b/documentation/01_tutorial/10-9-enemies-and-basic-ai.html.md
@@ -193,8 +193,8 @@ In order to let our enemies 'think', we're going to utilize a very simple [Finit
 	var brain:FSM;
 	var idleTimer:Float;
 	var moveDirection:Float;
-	var seesPlayer:Bool;
-	var playerPosition:FlxPoint;
+	public var seesPlayer:Bool;
+	public var playerPosition:FlxPoint;
 	```
 
 3. At the end of the constructor, add:


### PR DESCRIPTION
During the tutorial, both of these variables are declared with just the var keyword, later on, when we create the function `checkEnemyVision()` inside the PlayerState class, we get an error because these variables are private in the Enemy class.
I changed both variables to be public to match the demo files.