### PR TITLE
Update "Zooming game while leaving HUD intact"

### DIFF
--- a/documentation/03_resources/01-cheat-sheet.html.md
+++ b/documentation/03_resources/01-cheat-sheet.html.md
@@ -594,20 +594,18 @@ scrollFactor.set(0, 0);
 ### Zooming game while leaving HUD intact
 
 ```haxe
-gameCamera = new FlxCamera(0, 0, screenWidth, screenHeight);
+// create a new camera for the HUD
 uiCamera = new FlxCamera(0, 0, screenWidth, screenHeight);
-
-gameCamera.bgColor = 0xff626a71;
 uiCamera.bgColor = FlxColor.TRANSPARENT;
 
-gameCamera.zoom = 0.5;
+// add camera to list and set 'DefaultDrawTarget' to false
+FlxG.cameras.add(uiCamera, false);
 
-FlxG.cameras.reset(gameCamera);
-FlxG.cameras.add(uiCamera);
-
-FlxCamera.defaultCameras = [gameCamera];
-
+// add element to the camera
 hudElement.cameras = [uiCamera];
+
+FlxG.camera.bgColor = 0xff626a71;
+FlxG.camera.zoom = 0.5; // zoom only on the default camera
 ```
 
 


### PR DESCRIPTION
Because **"FlxCamera.defaultCamera"** is obsolete, I tried to rewrite the method that can perform this action.
I recently started with HaxeFlixel and this is how I implement it in the new version (4.9.0).

Maybe... should I put a warning that the method is obsolete instead of this?