### PR TITLE
Fix FlxBitmapText URL in Targets doc

### DIFF
--- a/documentation/02_handbook/08-haxeflixel-targets.html.md
+++ b/documentation/02_handbook/08-haxeflixel-targets.html.md
@@ -31,6 +31,6 @@ lime setup android
 ### HTML5
 
 #### General HTML5 Guidelines
-- **Text**: For now, you might prefer using [bitmap fonts](http://haxeflixel.com/demos/FlxBitmapTextField/) to avoid text issues. With regular fonts, you may favor larger text size (>12) in order to avoid blurriness, and try some [manual adjustments](https://github.com/HaxeFlixel/flixel/issues/1024) if you have a scaling problem (or when you are trying to embed fonts, which is not supported).
+- **Text**: For now, you might prefer using [bitmap fonts](https://haxeflixel.com/demos/FlxBitmapText/) to avoid text issues. With regular fonts, you may favor larger text size (>12) in order to avoid blurriness, and try some [manual adjustments](https://github.com/HaxeFlixel/flixel/issues/1024) if you have a scaling problem (or when you are trying to embed fonts, which is not supported).
 - **Audio**: You should use regular .ogg files . Though .mp3 and .wav files are supported, SoundJS may not recognise them and might stop your project from running until you delete/replace them.
 - **Particles**: You should keep the particle count low and not expect much in terms of performance.


### PR DESCRIPTION
The previous URL no longer works, so this updates it to the currently live Bitmap text demo.