### PR TITLE
Changed the gamepad list to have the switch controllers.

### DIFF
--- a/documentation/02_handbook/16-gamepads.html.md
+++ b/documentation/02_handbook/16-gamepads.html.md
@@ -10,6 +10,7 @@ Since gamepads have a variety of manufacturers their keycodes provided to HaxeFl
 - XInput (Xbox 360, Xbox One, etc)
 - PS4
 - OUYA
+- Switch Joycons/Pro Controllers
 - Logitech
 - WiiRemote
 - Mayflash WiiRemote


### PR DESCRIPTION
Very self-explanitory, I don't know if the switch controllers don't work and if that's why it isn't in the list, but i feel like not adding it into the list would throw some pepole off of adding switch support to their games.