### PR TITLE
Remove a «type» in excess

### DIFF
--- a/documentation/01_tutorial/04-3-groundwork.html.md
+++ b/documentation/01_tutorial/04-3-groundwork.html.md
@@ -65,7 +65,6 @@ First up, let's create a simple menu. Eventually, we'll want a fancy `MenuState`
 	First, we want the button to be in a nicer place. Sure, we could set the `x` and `y` coordinates when we create it, but there's a simpler way to do it.
 	
 	Back in `create()`, add a new line somewhere after we create our `FlxButton`, and before `super.create();` type:
-	Type:
 
 	```haxe
 	playButton.screenCenter();


### PR DESCRIPTION
In step 5, before creating a player, it says at the end «Back in create(), add a new line somewhere after we create our FlxButton, and before super.create(); type: Type:», so I removed the one in excess in order to be less "miswritten"