### PR TITLE
Update the resources category

### DIFF
--- a/documentation/03_resources/03-game-development-tools.html.md
+++ b/documentation/03_resources/03-game-development-tools.html.md
@@ -20,6 +20,10 @@ Inkscape supports many advanced SVG features (markers, clones, alpha blending, e
 
 Krita is a free digital painting and illustration application. Krita offers CMYK support, HDR painting, perspective grids, dockers, filters, painting assistants, and many other features you would expect.
 
+#### [Aseprite](https://www.aseprite.org/)
+
+Aseprite is a program designed for drawing pixel art. It has layers, animation tools, tile map tools, blend modes, and many more useful features. It's not free, but it's a favorite for many developers.
+
 ## Sound Editors
 
 #### [Audacity](http://www.audacityteam.org/)
@@ -44,21 +48,25 @@ LabChirp is a program for creating sound effects.
 
 ## Map Editors
 
-### [Tiled Map Editor](http://www.mapeditor.org/)
+#### [Tiled Map Editor](http://www.mapeditor.org/)
 
 Tiled is a general purpose tile map editor. It is meant to be used for editing maps of any tile-based game, be it an RPG, a platformer or a Breakout clone. [This demo shows how to load a Tiled map](http://haxeflixel.com/demos/TiledEditor/).
 
-### [Ogmo Editor](http://www.ogmoeditor.com/)
+#### [Ogmo Editor](http://www.ogmoeditor.com/)
 
 Ogmo Editor is a generic level editor for indie game developers who use Windows. It also happens to be free and open source. The editor is built to be reconfigurable, so you can set it up to work well for your game project. [This HaxeFlixel tutorial](http://haxeflixel.com/documentation/part-v-tiles-maps-and-collisions/) demonstrates how to create a simple top-down level with Ogmo.
 
+#### [LDtk](https://ldtk.io/)
+
+LDtk is a level editor created by the lead game designer of [Dead Cells](https://store.steampowered.com/app/588650/Dead_Cells/). This editor has some extra features work nicely with Haxe and HaxeFlixel, and focuses on being easy to use. This tutorial shows you how to use LDtk tile maps with HaxeFlixel.
+
 ## Asset Utilities
 
-### [ShoeBox](http://renderhjs.net/shoebox/)
+#### [ShoeBox](http://renderhjs.net/shoebox/)
 
 ShoeBox is a free Adobe Air based app for Windows and Mac OS X with game and UI related tools. It has many utilities that make asset management easier, such as [sprite packing](http://renderhjs.net/shoebox/packSprites.htm), [sprite extraction](http://renderhjs.net/shoebox/extractSprites.htm), [texture ripping](http://renderhjs.net/shoebox/textureRipper.htm), [bitmap font creation](http://renderhjs.net/shoebox/bitmapFont.htm), and more.
 
-### [Texture Packer](https://www.codeandweb.com/texturepacker)
+#### [Texture Packer](https://www.codeandweb.com/texturepacker)
 
 Texture Packer does one thing very well - it packs several sprites into one large image to help reduce load times for your game. It's easy to use and easy to integrate with HaxeFlixel. [This demo shows how to use a TexturePackerAtlas](http://haxeflixel.com/demos/TexturePackerAtlas/).
 

--- a/documentation/03_resources/03-game-development-tools.html.md
+++ b/documentation/03_resources/03-game-development-tools.html.md
@@ -58,7 +58,7 @@ Ogmo Editor is a generic level editor for indie game developers who use Windows.
 
 #### [LDtk](https://ldtk.io/)
 
-LDtk is a level editor created by the lead game designer of [Dead Cells](https://store.steampowered.com/app/588650/Dead_Cells/). This editor has some extra features work nicely with Haxe and HaxeFlixel, and focuses on being easy to use. This tutorial shows you how to use LDtk tile maps with HaxeFlixel.
+LDtk is a level editor created by the lead game designer of [Dead Cells](https://store.steampowered.com/app/588650/Dead_Cells/). This editor has some extra features work nicely with Haxe and HaxeFlixel, and focuses on being easy to use. [This tutorial](https://goop.wtf/2021/06/05/loading-ldtk-maps-in-haxeflixel.html) shows you how to use LDtk tile maps with HaxeFlixel.
 
 ## Asset Utilities
 

--- a/documentation/03_resources/05-using-haxelib.html.md
+++ b/documentation/03_resources/05-using-haxelib.html.md
@@ -2,7 +2,7 @@
 title: "Using Haxelib"
 ```
 
-Haxelib is a package manager and utility that comes with your Haxe install. Here are the most used commands, the full usage docs are [available here](http://haxe.org/doc/haxelib/using_haxelib).
+Haxelib is a package manager and utility that comes with your Haxe install. Here are the most used commands, the full usage docs are [available here](https://lib.haxe.org/documentation/using-haxelib/).
 
 ### Installing a Library
 
@@ -36,6 +36,14 @@ Remove a library:
 
 ```
 haxelib remove <library>
+```
+
+### Using An Installed Library
+
+To use a library in your HaxeFlixel project, add it to your `project.xml`:
+
+```xml
+<haxelib name="<library>" />
 ```
 
 ### Updating Haxelib itself


### PR DESCRIPTION
I made the following changes to the Resources category:

- Add Aseprite to Game Development Tools, under Graphics Editors. It feels odd not having a pixel art focused program here, aside from the passing mention of using Paint.NET for it.
- Add LDtk to Game Development Tools, under Map Editors. LDtk is a very Haxe friendly editor with HaxeFlixel integration, so it makes sense.
- Fix the inconsistent headings. Map Editors and Asset Utilities had bigger headings than the other two sections.
- Add a section to Using Haxelib about using libraries in your project after you install them.
- Fix the dead link in Using Haxelib.