### PR TITLE
Implement Dark Mode from Dox

### DIFF
--- a/api/dox/haxe_libraries/dox.hxml
+++ b/api/dox/haxe_libraries/dox.hxml
@@ -1,4 +1,4 @@
-# @install: lix --silent download "haxelib:/dox#1.5.0" into dox/1.5.0/haxelib
-# @run: haxelib run-dir dox ${HAXE_LIBCACHE}/dox/1.5.0/haxelib
--cp ${HAXE_LIBCACHE}/dox/1.5.0/haxelib/src
--D dox=1.5.0
+# @install: lix --silent download "haxelib:/dox#1.6.0" into dox/1.6.0/haxelib
+# @run: haxelib run-dir dox ${HAXE_LIBCACHE}/dox/1.6.0/haxelib
+-cp ${HAXE_LIBCACHE}/dox/1.6.0/haxelib/src
+-D dox=1.6.0

--- a/api/dox/theme/resources/extra-styles.css
+++ b/api/dox/theme/resources/extra-styles.css
@@ -2,6 +2,14 @@
 
 /* nav */
 
+body:not(.dark-theme) {
+  background-color: #dfebe7;
+}
+
+body .dark-theme {
+  background-color: #111111;
+}
+
 nav a {
   font-family: 'Ubuntu', sans-serif;
   padding-top: 14px !important;
@@ -17,10 +25,8 @@ nav a {
   margin-left: 15px;
 }
 
-body {
-  background-image: url(https://haxeflixel.com/images/highlight-bg.png), url(https://haxeflixel.com//images/site-bg.png);
-  background-repeat: no-repeat, repeat;
-  background-position: center top, left top;
+.navbar #theme-toggle {
+  margin-left: 0px;
 }
 
 div.main-content > div {
@@ -32,6 +38,11 @@ div.main-content > div {
   padding: 16px;
   overflow: hidden;
   padding-top: 50px;
+}
+
+.dark-theme div.main-content > div {
+  background: #111111;
+  border-color: #080808;
 }
 
 .navbar{position:relative;z-index:1000;min-height:50px;margin-bottom:22px;border:1px solid transparent}.navbar:before,.navbar:after{content:" ";display:table;}

--- a/api/dox/theme/templates/topbar.mtt
+++ b/api/dox/theme/templates/topbar.mtt
@@ -41,6 +41,9 @@
 					<li>
 						<a href="https://github.com/HaxeFlixel/flixel/discussions">Forum</a>
 					</li>
+					<li>
+						<a href="#" id="theme-toggle" class="brand" style="color:$$getHexValue(::textColor::)" onclick="toggleTheme()" title="Toggle Dark Mode"><i class="fa fa-moon-o"></i></a>
+					</li>
 				</ul>
 			</div>
 		</div>


### PR DESCRIPTION
Dox 1.6.0 already has support for Dark Mode, so I simply bumped up the version from 1.5.0 to 1.6.0, and tidied up some colouring things, and added the dark mode toggle in the header to swap!