### PR TITLE
renamed "forums" to "Github Discussions page"

### DIFF
--- a/documentation/04_community/00-community.html.md
+++ b/documentation/04_community/00-community.html.md
@@ -8,7 +8,7 @@ HaxeFlixel is a collaborative project from [contributors all over the world](htt
 If you need help or just want to chat , HaxeFlixel has a...
 
 - [Discord Server](https://discordapp.com/invite/rqEBAgF) (most active)
-- [Forum](https://github.com/HaxeFlixel/flixel/discussions)
+- [Github Discussions page](https://github.com/HaxeFlixel/flixel/discussions)
 - [StackOverflow Tag](https://stackoverflow.com/questions/tagged/haxeflixel)
 
 Other HaxeFlixel-related pages:


### PR DESCRIPTION
more accurately describes where the link leads!