### PR TITLE
Add an Community Tutorials section to Resources

### DIFF
--- a/documentation/03_resources/06-faq.html.md
+++ b/documentation/03_resources/06-faq.html.md
@@ -8,14 +8,10 @@ No, you have to learn HaxeFlixel to use HaxeFlixel, although previous experience
 #### Do I have to learn OpenFL to use HaxeFlixel?
 No, HaxeFlixel abstracts it completely.
 
-#### Are there any tutorials?
+#### Are there any more tutorials?
+We have a dedicated [**Community Tutorials** page](https://haxeflixel.com/documentation/community-tutorials) that links to many external community made tutorials! 
 
-- [@SeiferTim's](https://twitter.com/SeiferTim) [Dungeon Crawler Tutorial](https://haxeflixel.com/documentation/tutorial/)
-
-- [atomicptr's](https://github.com/atomicptr/GameMechanicExplorer-HaxeFlixel) [Game Mechanic Explorer port](http://gme.qr9.de/)
-
-- [Videos from Christopher Butler](https://www.youtube.com/watch?v=LpKvSPwHOP8&list=PLi0ypjD5PcV9xdjycW0hYi_HD297012tE)
-(covering everything from installation to prototyping a platformer).
+You can find the official HaxeFlixel "Dungeon Crawler" tutorial [here](https://haxeflixel.com/documentation/tutorial/).
 
 #### I found a bug, where to report?
 On the [official GitHub repository](https://github.com/HaxeFlixel/flixel/issues).

--- a/documentation/03_resources/07-community-tutorials.html.md
+++ b/documentation/03_resources/07-community-tutorials.html.md
@@ -4,6 +4,11 @@ title: "Community Tutorials"
 While we try our best to make good documentation and a good example tutorial, we can only do so much! 
 So this will be a big list to various external Community Tutorials made by other people!
 
+## Written
+
+- [(2023) Tim’s Tips #1: Texture Packing Sprites](https://axolstudio.com/articles/2023-07-23-tims-tips-1-texture-packing-sprites/)
+
 ## Videos
 
 - [(Playlist - 2024) Learn Haxe with HaxeFlixel - Luke Makes Games ](https://www.youtube.com/playlist?list=PLLrBJXzcw-ddqs3tf31Qj-eN67WwR-uQa)
+- [(Playlist - 2021) Code Along: Breakout - Axol Studios](https://www.youtube.com/playlist?list=PL0mTR4YHxhDhD39potymkrbI44DzwTyi8)

--- a/documentation/03_resources/07-community-tutorials.html.md
+++ b/documentation/03_resources/07-community-tutorials.html.md
@@ -1,8 +1,8 @@
 ```
-title: "Tutorials"
+title: "Community Tutorials"
 ```
 While we try our best to make good documentation and a good example tutorial, we can only do so much! 
-So this will be a big list to various EXTERNAL Tutorials made by other people!
+So this will be a big list to various external Community Tutorials made by other people!
 
 ## Videos
 

--- a/documentation/03_resources/07-tutorials.html.md
+++ b/documentation/03_resources/07-tutorials.html.md
@@ -6,4 +6,4 @@ So this will be a big list to various EXTERNAL Tutorials made by other people!
 
 ## Videos
 
-- [(Playlist - 2024) Learn Haxe with HaxeFlixel - Luke Makes Games ](https://www.youtube.com/playlist?list=PLLrBJXzcw-ddqs3tf31Qj-eN67WwR-uQa)https://www.youtube.com/playlist?list=PLLrBJXzcw-ddqs3tf31Qj-eN67WwR-uQa
+- [(Playlist - 2024) Learn Haxe with HaxeFlixel - Luke Makes Games ](https://www.youtube.com/playlist?list=PLLrBJXzcw-ddqs3tf31Qj-eN67WwR-uQa)

--- a/documentation/03_resources/07-tutorials.html.md
+++ b/documentation/03_resources/07-tutorials.html.md
@@ -1,0 +1,6 @@
+```
+title: "Tutorials"
+```
+While we try our best to make good documentation and a good example tutorial, we can only do so much! 
+So this will be a big list to various EXTERNAL Tutorials made by other people!
+

--- a/documentation/03_resources/07-tutorials.html.md
+++ b/documentation/03_resources/07-tutorials.html.md
@@ -4,3 +4,6 @@ title: "Tutorials"
 While we try our best to make good documentation and a good example tutorial, we can only do so much! 
 So this will be a big list to various EXTERNAL Tutorials made by other people!
 
+## Videos
+
+- [(Playlist - 2024) Learn Haxe with HaxeFlixel - Luke Makes Games ](https://www.youtube.com/playlist?list=PLLrBJXzcw-ddqs3tf31Qj-eN67WwR-uQa)https://www.youtube.com/playlist?list=PLLrBJXzcw-ddqs3tf31Qj-eN67WwR-uQa


### PR DESCRIPTION
draft PR for now, relevant issue #273 

In here and/or the issues post, if we can collect a few tutorials to add, can get this one rolling and published 

Feel free to let me know on any notes related to how to FORMAT the list of things (how many ### for headings, link format, etc.)

Felt like "community tutorials" was the best description