### PR TITLE
convert backticks to dashes in frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ This is the main location for HaxeFlixel documentation. Pull requests from this 
 The main documentation is made up of `*.html.md` files in the `./documentation` folder. Each file and folder starts with a numerical prefix specifying the order listed on the [docpad website](https://github.com/HaxeFlixel/haxeflixel.com).
 
 Additional pages can be added using the same extension and using a header specifying the title as seen in the other pages. Eg:
-
-	```
+```
+	---
 	title: "Documentation Page"
-	```
-	
+	---
+```	
 	Use Regular GitHub flavoured markdown for the page.
 	Note `title:` above is case sensitive.
 

--- a/documentation/00_getting_started/00-getting-started.html.md
+++ b/documentation/00_getting_started/00-getting-started.html.md
@@ -1,7 +1,7 @@
-```
+---
 title: "Getting Started"
 rootDoc: true
-```
+---
 
 Welcome to HaxeFlixel! To setup your Windows, Linux or Mac system to start making games, there are three steps:
 

--- a/documentation/00_getting_started/01-install-haxeflixel.html.md
+++ b/documentation/00_getting_started/01-install-haxeflixel.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "Install HaxeFlixel"
-```
+---
 
 To install the latest stable version of HaxeFlixel, open a command prompt and run the following [Haxelib](http://lib.haxe.org/) commands:
 
@@ -14,13 +14,13 @@ After the installation is complete, you can compile games to HTML5, Flash and Ne
 
 To easily install additional libraries (addons, ui, demos, tools, templates...) in a single step, just run:
 
-```bash
+``` bash
 haxelib run lime setup flixel
 ```
 
 ### Install the `lime` command
 
-```bash
+``` bash
 haxelib run lime setup
 ```
 

--- a/documentation/00_getting_started/02-hello-world.html.md
+++ b/documentation/00_getting_started/02-hello-world.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "Hello World"
-```
+---
 
 "Hello World" is a [common example](http://en.wikipedia.org/wiki/Hello_world_program) of getting started with programming, here we will show you how to add Hello World with HaxeFlixel's `FlxText`. You can compile this test for any supported target platform.
 

--- a/documentation/00_getting_started/03-visual-studio-code.html.md
+++ b/documentation/00_getting_started/03-visual-studio-code.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "Visual Studio Code"
-```
+---
 
 [![](../images/00_getting_started/vscode/vscode-plus-extensions.png)](https://marketplace.visualstudio.com/items?itemName=vshaxe.haxe-extension-pack)
 

--- a/documentation/00_getting_started/04-where-to-now.html.md
+++ b/documentation/00_getting_started/04-where-to-now.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "Where to now?"
-```
+---
 
 If you have successfully compiled a Hello World sample, there are multiple places to jump to from here:
 

--- a/documentation/01_tutorial/00-tutorial.html.md
+++ b/documentation/01_tutorial/00-tutorial.html.md
@@ -1,7 +1,7 @@
-```
+---
 title: "Tutorial"
 rootDoc: true
-```
+---
 
 Welcome to HaxeFlixel! In this tutorial, you will learn how to create a complete game in HaxeFlixel from start to finish, and then some. Each step is broken into smaller chunks to help you get through even the most complicated and daunting steps.
 

--- a/documentation/01_tutorial/01-the-power-of-haxeflixel.html.md
+++ b/documentation/01_tutorial/01-the-power-of-haxeflixel.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "The Power of HaxeFlixel"
-```
+---
 
 First, let me talk a bit about why you should use HaxeFlixel.
 

--- a/documentation/01_tutorial/02-1-setup.html.md
+++ b/documentation/01_tutorial/02-1-setup.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "1 - Setup"
-```
+---
 
 The first things we need to do is install all of the components we need to work with HaxeFlixel. For that, please follow our general [Getting Started](/documentation/getting-started/) guide. This will get you:
 

--- a/documentation/01_tutorial/03-2-creating-a-new-project.html.md
+++ b/documentation/01_tutorial/03-2-creating-a-new-project.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "2 - Creating a new project"
-```
+---
 
 Now we want to make sure that everything is installed properly - and we want to set up the framework for our game. So we're going to make a new project, open it with VSCode and test that it builds and runs.
 

--- a/documentation/01_tutorial/04-3-groundwork.html.md
+++ b/documentation/01_tutorial/04-3-groundwork.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "3 - Groundwork"
-```
+---
 
 Now it's time to think about what we actually want our game to be, and how we're going to pull it off.
 

--- a/documentation/01_tutorial/05-4-sprites-and-animation.html.md
+++ b/documentation/01_tutorial/05-4-sprites-and-animation.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "4 - Sprites and Animation"
-```
+---
 
 So we have a player sprite that moves around the screen. Great! But… we don't want it to just look like a block… so let's add some graphics!
 

--- a/documentation/01_tutorial/06-5-creating-a-tilemap.html.md
+++ b/documentation/01_tutorial/06-5-creating-a-tilemap.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "5 - Creating a Tilemap"
-```
+---
 
 Now it's time to make some maps for the player to move around in! To do this, we're going to use a tool called _Ogmo Editor_. Ogmo is a free tilemap editor that works very nicely with HaxeFlixel. For this part of the tutorial, we're just going to use a simple 2-tile tilesheet with a tile for walls and a tile for floors.
 

--- a/documentation/01_tutorial/07-6-loading-the-tilemap.html.md
+++ b/documentation/01_tutorial/07-6-loading-the-tilemap.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "6 - Loading the Tilemap"
-```
+---
 
 One of the great things about using Ogmo with HaxeFlixel is that there is already a built-in class to load and use the maps. However, it's not in the 'standard' HaxeFlixel library - we have to install the flixel-addons library to get access to it.
 

--- a/documentation/01_tutorial/08-7-zoom-and-cameras.html.md
+++ b/documentation/01_tutorial/08-7-zoom-and-cameras.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "7 - Zoom and Cameras"
-```
+---
 
 When you run your game now, you'll notice that everything is really, really small. We're going to make it more visible by applying some zoom to our game so that we can get a better look at the action. This is a pretty quick change:
 

--- a/documentation/01_tutorial/09-8-pickups.html.md
+++ b/documentation/01_tutorial/09-8-pickups.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "8 - Pickups"
-```
+---
 
 Now that we have our little guy running around our map, lets give him something to pick up. We'll add some simple coins that will add to the player's score when they are picked up.
 

--- a/documentation/01_tutorial/10-9-enemies-and-basic-ai.html.md
+++ b/documentation/01_tutorial/10-9-enemies-and-basic-ai.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "9 - Enemies and Basic AI"
-```
+---
 
 What would a dungeon game be without enemies? Let's add some!
 

--- a/documentation/01_tutorial/11-10-ui-and-combat.html.md
+++ b/documentation/01_tutorial/11-10-ui-and-combat.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "10 - UI and Combat"
-```
+---
 
 Now we want to show the player what's going on. So we need to have some kind of HUD on the screen to tell them what their current/max health is, and how many coins they have. For the health icon you can use this image ![](https://raw.githubusercontent.com/HaxeFlixel/flixel-demos/master/Tutorials/TurnBasedRPG/assets/images/health.png), or make your own. Make sure you save this in `assets/images`.
 

--- a/documentation/01_tutorial/12-11-game-over-menu.html.md
+++ b/documentation/01_tutorial/12-11-game-over-menu.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "11 - Game Over Menu"
-```
+---
 
 Our game is really starting to come together! Now we need it to feel more like a 'game' with a win and lose scenario. For our (very simple) game, we'll just make it so that if you ever die in combat, you get a Game Over, and when you beat the boss enemy, you win. Both of these conditions will take you to the same `FlxState` to show you your score and allow you to play again if you want.
 

--- a/documentation/01_tutorial/13-12-sound-and-music.html.md
+++ b/documentation/01_tutorial/13-12-sound-and-music.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "12 - Sound and Music"
-```
+---
 
 Our game is really coming together now, but it's still missing something… there's no _sound_ yet!
 

--- a/documentation/01_tutorial/14-13-multiple-platforms.html.md
+++ b/documentation/01_tutorial/14-13-multiple-platforms.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "13 - Multiple Platforms"
-```
+---
 
 One of the big advantages of using HaxeFlixel is the ability to build your games for multiple platforms. You can build a working HTML5, Windows, Linux, Mac, Android and iOS game - all from the same code! So far, we've been working with HTML5, and, for the most part, you don't have to do too much to get your game working on other platforms - if you test it under Windows right now, it should mostly work just fine (although, without music, which we'll discuss later). However, you might run into some issues if you try to build it for a mobile device - at the very least, you won't be able to play it without a keyboard. We'll focus on Windows and Android in this tutorial and add a few things to make them work better on those platforms.
 

--- a/documentation/01_tutorial/15-14-polish.html.md
+++ b/documentation/01_tutorial/15-14-polish.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "14 - Polish"
-```
+---
 
 In this section, you're going to learn a few simple tricks to add some polish and juice to your game. Some of those have already been added here and there, but we'll go through a few places now to talk about them.
 

--- a/documentation/01_tutorial/16-conclusion.html.md
+++ b/documentation/01_tutorial/16-conclusion.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "Conclusion"
-```
+---
 
 Now we have a pretty complete, working game! It's not too complex, but it should give you a full, well-rounded idea of how to make your own games in HaxeFlixel. I really hope you've enjoyed this tutorial, and take the time to play around with the code some more to try expanding the game even further. You could add more levels, add stairway objects to move between them, add more enemy types, and collectibles, and upgrades… the list goes on.
 

--- a/documentation/02_handbook/00-haxeflixel-handbook.html.md
+++ b/documentation/02_handbook/00-haxeflixel-handbook.html.md
@@ -1,7 +1,7 @@
-```
+---
 title: "HaxeFlixel Handbook"
 rootDoc: true
-```
+---
 
 Welcome to the HaxeFlixel handbook. These pages are intended to answer common questions and explain the main ideas and structures behind most HaxeFlixel games.
 As the types of games and use cases of HaxeFlixel are vast we appreciate developers making additions and improvements to this documentation through [GitHub](https://github.com/HaxeFlixel/flixel-docs).

--- a/documentation/02_handbook/01-flixel-display-list.html.md
+++ b/documentation/02_handbook/01-flixel-display-list.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "Flixel Display List"
-```
+---
 The Flixel Display list is a specially designed structure for your game's sprites to be rendered.
 
 #### `FlxSprite` != `flash.display.Sprite`

--- a/documentation/02_handbook/02-flxgroup.html.md
+++ b/documentation/02_handbook/02-flxgroup.html.md
@@ -1,7 +1,7 @@
-```
+---
 title: "FlxGroup"
 apiPath: group/FlxTypedGroup.html
-```
+---
 
 ```haxe
 import flixel.group.FlxGroup;

--- a/documentation/02_handbook/03-flxsprite.html.md
+++ b/documentation/02_handbook/03-flxsprite.html.md
@@ -1,7 +1,7 @@
-```
+---
 title: "FlxSprite"
 apiPath: FlxSprite.html
-```
+---
 
 ```haxe
 import flixel.FlxSprite;

--- a/documentation/02_handbook/04-flxstate.html.md
+++ b/documentation/02_handbook/04-flxstate.html.md
@@ -1,7 +1,7 @@
-```
+---
 title: "FlxState"
 apiPath: FlxState.html
-```
+---
 
 This is the basis for your game's levels and menus, each described in a "state" structure. The state is a way of organising your game objects for the state that the game is currently in. For example, when you create level 0 of your game it's much more organized to only have the code for that level, not every level. Also it's good to use switching states to clear your memory, to avoid memory leaks. A typical Flixel game will have a separate `FlxState` class for every level and menu.
 

--- a/documentation/02_handbook/05-flxsave.html.md
+++ b/documentation/02_handbook/05-flxsave.html.md
@@ -1,7 +1,7 @@
-```
+---
 title: "FlxSave"
 apiPath: util/FlxSave.html
-```
+---
 
 ```haxe
 import flixel.util.FlxSave;

--- a/documentation/02_handbook/06-flxtween.html.md
+++ b/documentation/02_handbook/06-flxtween.html.md
@@ -1,7 +1,7 @@
-```
+---
 title: "FlxTween"
 apiPath: tweens/FlxTween.html
-```
+---
 
 A `FlxTween` allows you to create smooth interpolations and animations easily. Tweening is short for [inbetweening](http://en.wikipedia.org/wiki/Inbetweening): you only have to specify start and end values and the `FlxTween` class will generate all values between those two. If you want to see a `FlxTween` in action, this [tween demo](http://haxeflixel.com/demos/FlxTween/) is available.
 

--- a/documentation/02_handbook/07-haxeflixel-conditionals.html.md
+++ b/documentation/02_handbook/07-haxeflixel-conditionals.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "HaxeFlixel Conditionals"
-```
+---
 
 ### What is "conditional compilation"?
 

--- a/documentation/02_handbook/08-haxeflixel-targets.html.md
+++ b/documentation/02_handbook/08-haxeflixel-targets.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "HaxeFlixel Targets"
-```
+---
 
 HaxeFlixel currently supports the following targets through OpenFL:
 

--- a/documentation/02_handbook/09-desktop-targets.html.md
+++ b/documentation/02_handbook/09-desktop-targets.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "Desktop Targets"
-```
+---
 
 The desktop targets of HaxeFlixel run on all mainstream operating systems (OSX, Windows and Linux). They are all compiled to C++ through the Hxcpp library and are rendered through interfacing with the [Simple DirectMedia Layer.](http://libsdl.org) The code for this part of the library is developed through [NME ](https://github.com/haxenme/NME)which provides dll libs that openfl interfaces with.
 

--- a/documentation/02_handbook/10-mobile-targets.html.md
+++ b/documentation/02_handbook/10-mobile-targets.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "Mobile Targets"
-```
+---
 
 With the penetration of mobile devices in the world ignoring mobile targets for your games and applications is ignoring a huge audience.
 

--- a/documentation/02_handbook/11-android.html.md
+++ b/documentation/02_handbook/11-android.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "Android"
-```
+---
 
 <img src="/images/targets/android-logo.svg" width="160px" style="float:left; padding:10px" />
 

--- a/documentation/02_handbook/12-ios.html.md
+++ b/documentation/02_handbook/12-ios.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "iOS"
-```
+---
 
 <img src="/images/targets/ios-logo.png" width="160px" style="float:left; padding:10px" />
 

--- a/documentation/02_handbook/13-neko.html.md
+++ b/documentation/02_handbook/13-neko.html.md
@@ -1,6 +1,6 @@
-```
+---
 title: "Neko"
-```
+---
 
 <img src="../images/02_handbook/nekovm-logo.png" width="128px" style="float:left; padding:10px" />
 

--- a/documentation/02_handbook/14-keyboard.html.md
+++ b/documentation/02_handbook/14-keyboard.html.md
@@ -1,7 +1,7 @@
-```
+---
 title: "Keyboard"
 apiPath: input/keyboard/FlxKeyboard.html
-```
+---
 
 Keyboard input for HaxeFlixel is provided through the `FlxKeyboard` class and is available through `FlxG.keys`.
 

--- a/documentation/02_handbook/15-mouse.html.md
+++ b/documentation/02_handbook/15-mouse.html.md
@@ -1,7 +1,7 @@
-```
+---
 title: "Mouse"
 apiPath: input/mouse/FlxMouse.html
-```
+---
 
 Mouse input for HaxeFlixel is provided through the `FlxMouse` class and is available through `FlxG.mouse`. It is worth noting that it extends `FlxPoint`.
 

--- a/documentation/02_handbook/16-gamepads.html.md
+++ b/documentation/02_handbook/16-gamepads.html.md
@@ -1,8 +1,7 @@
-```
+---
 title: "Gamepads"
 apiPath: input/gamepad/index.html
-```
-
+---
 Gamepad input for HaxeFlixel is provided through the `FlxGamepad` class and is available through `FlxG.gamepads` and the `InputFrontEnd`.
 
 Since gamepads have a variety of manufacturers their keycodes provided to HaxeFlixel API differ from model to model. HaxeFlixel provides mappings that map buttons and sticks to common IDs for convenient use. Mappings are available for:

--- a/documentation/02_handbook/17-actions.html.md
+++ b/documentation/02_handbook/17-actions.html.md
@@ -1,8 +1,7 @@
-```
+---
 title: "Actions"
 apiPath: input/actions/index.html
-```
-
+---
 Players & designers care about *actions* (Mario *jumps*, Samus *shoots*, Captain 
 Falcon *turns*, *brakes*, and *accelerates*), whereas computers care about 
 *inputs* (The W key is `PRESSED`, the left mouse button was `JUST_RELEASED`, 

--- a/documentation/02_handbook/19-debugger.html.md
+++ b/documentation/02_handbook/19-debugger.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Debugger"
-```
-
+---
 Flixel comes with a fairly powerful debugging overlay. You can open it with one of the default toggle keys (`F2`, \` and \ with a QWERTY keyboard layout). Note that these are configurable via `FlxG.debugger.toggleKeys`. Alternatively, you can do the same in code via the `FlxG.debugger.visible` flag.
 
 Note that the debugger does not exist when compiling with `FLX_NO_DEBUG`. With the default `Project.xml`, this is the case in release mode. On the command line, use the `-debug` flag to build in debug mode instead (e.g. `lime test neko -debug`).

--- a/documentation/02_handbook/20-debugger-interaction.html.md
+++ b/documentation/02_handbook/20-debugger-interaction.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Debugger - Interaction"
-```
-
+---
 The interaction tool (enabled by the ![](../images/02_handbook/debugger/icons/interactive.png) button in the debugger overlay) allows you to change game elements, e.g. move sprites, while the game is still running.
 
 It is highly recommended, however, that you pause the game using VCR's pause button ![](../images/02_handbook/debugger/icons/pause.png) before using the interaction tool. You can always resume the game by clicking VCR's play button ![](../images/02_handbook/debugger/icons/arrowRight.png) after you are done with the interaction. If the game is not paused during the interaction, objects affected by acceleration, for instance, will continue to move, making your work harder.

--- a/documentation/03_resources/00-resources.html.md
+++ b/documentation/03_resources/00-resources.html.md
@@ -1,8 +1,7 @@
-```
+---
 title: "Resources"
 rootDoc: true
-```
-
+---
 Developing games in general is made easier by making the most of the resources in communities both online and offline. 
 
 We are here collecting resources to help you learn and make games. Code snippets, tutorials and general information for game development is all wanted, so please make a pull request to these pages and make these resources even better!

--- a/documentation/03_resources/01-cheat-sheet.html.md
+++ b/documentation/03_resources/01-cheat-sheet.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Cheat Sheet"
-```
-
+---
 ## [FlxSprite](http://haxeflixel.com/documentation/flxsprite) (Base)
 
 ```haxe

--- a/documentation/03_resources/02-openfl-project-xml-format.html.md
+++ b/documentation/03_resources/02-openfl-project-xml-format.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "XML Project Format"
-```
-
+---
 Every OpenFL project uses an XML file to setup the compile settings for your projects depending on your chosen target. This includes stage size, source paths, asset paths and more.
 
 [Click here to see the Project.xml from the default HaxeFlixel template.](http://github.com/HaxeFlixel/flixel-templates/blob/master/default/Project.xml.tpl)

--- a/documentation/03_resources/03-game-development-tools.html.md
+++ b/documentation/03_resources/03-game-development-tools.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Game Development Tools"
-```
-
+---
 ## Graphics Editors
 
 #### [Gimp](http://www.gimp.org/)

--- a/documentation/03_resources/04-compiler-conditionals.html.md
+++ b/documentation/03_resources/04-compiler-conditionals.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Compiler Conditionals"
-```
-
+---
 The Haxe compiler provides a robust solution for cross-platform development where you can use operators to define what targets receive your code. This functionality is invaluable for HaxeFlixel since we are targeting native mobile / desktop and web targets, all with different capabilities.
 
 [Conditional Compilation in the Haxe Manual](https://haxe.org/manual/lf-condition-compilation.html)

--- a/documentation/03_resources/05-using-haxelib.html.md
+++ b/documentation/03_resources/05-using-haxelib.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Using Haxelib"
-```
-
+---
 Haxelib is a package manager and utility that comes with your Haxe install. Here are the most used commands, the full usage docs are [available here](https://lib.haxe.org/documentation/using-haxelib/).
 
 ### Installing a Library

--- a/documentation/03_resources/06-faq.html.md
+++ b/documentation/03_resources/06-faq.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "FAQ"
-```
-
+---
 #### Do I have to learn Flixel (AS3) before HaxeFlixel?
 No, you have to learn HaxeFlixel to use HaxeFlixel, although previous experience with the AS3 version will help.
 

--- a/documentation/04_community/00-community.html.md
+++ b/documentation/04_community/00-community.html.md
@@ -1,8 +1,7 @@
-```
+---
 title: "Community"
 rootDoc: true
-```
-
+---
 HaxeFlixel is a collaborative project from [contributors all over the world](https://github.com/HaxeFlixel/flixel/graphs/contributors).
 
 If you need help or just want to chat , HaxeFlixel has a...

--- a/documentation/04_community/01-about.html.md
+++ b/documentation/04_community/01-about.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "About"
-```
-
+---
 HaxeFlixel is an open source 2D game engine written for use with the [Open Flash Library](https://github.com/openfl) and the [Haxe Toolkit](http://haxe.org), it is completely free for personal or commercial use. It enables multi-platform development for native targets on mobile and desktop as well as Flash and HTML5 on web platforms. 
 
 This project was founded by Alexander Hohlov, also known on [Beeblerox](https://github.com/Beeblerox) on GitHub, who continues to be the project lead for the [HaxeFlixel Organisation](https://github.com/HaxeFlixel) group. The project itself also has an active community with contributions from highly valued developers (by GitHub names) [GameDevSam](https://github.com/gamedevsam), [impaler](https://github.com/impaler), [Werdn](https://github.com/werdn), [ProG4mr](https://github.com/ProG4mr), [Gama11](https://github.com/gama11), [sergey-miryanov](https://github.com/sergey-miryanov) and more.

--- a/documentation/04_community/02-why-haxe.html.md
+++ b/documentation/04_community/02-why-haxe.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Why a Haxe Version"
-```
-
+---
 The original ActionScript 3 version of [Flixel](http://flixel.org) has proven to be an effective codebase to make 2D games quickly and easily for the Adobe Flash and AIR runtimes. [Haxe](http://haxe.org) and the [Open Flash Library](https://github.com/openfl) provide significant enhancements and opportunities that ActionScript 3, AIR and Flash are limited by. [Haxe](http://haxe.org) and the [OpenFL](https://github.com/openfl) offers more efficient and open source native runtimes to your code base that ActionScript 3 and Adobe Flash/Air are not able to provide. HaxeFlixel still retains the same Flash Player target, but you gain a[ familiar, yet superior](http://www.openfl.org/archive/developer/documentation/actionscript-developers/) open source language [Haxe](http://haxe.org).
 
 #### Use of a superior open source, cross-compiled language

--- a/documentation/04_community/04-introduction-to-openfl.html.md
+++ b/documentation/04_community/04-introduction-to-openfl.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Introduction to OpenFL"
-```
-
+---
 <img src="/images/openfl.jpg" width="100%" />
 
 The [Open Flash Library](http://www.openfl.org) (OpenFL) previously known as NME, is an innovative framework designed to provide fast, productive development for Windows, Mac, Linux, iOS, Android, Flash and HTML5 – all using the same source code.

--- a/documentation/04_community/05-contributing.html.md
+++ b/documentation/04_community/05-contributing.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Contributing"
-```
-
+---
 We welcome new contributors to this project.
 Being open source and followed by people all over the world, you can help in many ways.
 

--- a/documentation/04_community/06-code-contributions.html.md
+++ b/documentation/04_community/06-code-contributions.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Code Contributions"
-```
-
+---
 Contributing code to HaxeFlixel is done all through the official git repositories on [GitHub](http://www.github.com/haxeflixel).
 
 ### Use the Dev Branches

--- a/documentation/04_community/07-code-style.html.md
+++ b/documentation/04_community/07-code-style.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Code Style"
-```
-
+---
 This page contains a few notes on HaxeFlixel's code style. Note that we use [haxe-formatter](https://github.com/HaxeCheckstyle/haxe-formatter) to enforce consistent whitespace usage, bracket placement etc, so this page only focuses on naming conventions and other good practices not covered by an auto-formatter.
 
 ## Functions

--- a/documentation/04_community/08-website-docs.html.md
+++ b/documentation/04_community/08-website-docs.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: HaxeFlixel Website
-```
-
+---
 This website is built using the Docpad system which compiles the files to a static site on a community sponsored host.
 Extensions and help with improving the website and our documentation are greatly appreciated.
 

--- a/documentation/04_community/09-upgrade-guide-3-x.html.md
+++ b/documentation/04_community/09-upgrade-guide-3-x.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Upgrade Guide 3.x"
-```
-
+---
 ## 3.3.0
 
 The minimum Haxe version for this release is 3.1.0.

--- a/documentation/04_community/10-flixel-addons.html.md
+++ b/documentation/04_community/10-flixel-addons.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Flixel Addons"
-```
-
+---
 The addons are a set of very useful, but nevertheless *optional* classes that not every game is going to need. That is why they are not quite important enough to be a part of HaxeFlixel's core.
 
 ## Installing flixel-addons

--- a/documentation/04_community/11-upgrade-guide-4-0-0.html.md
+++ b/documentation/04_community/11-upgrade-guide-4-0-0.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Upgrade Guide 4.0.0"
-```
-
+---
 ## 4.4.0
 
 Breaking changes in 4.4.0 are limited to usage with OpenFL 8. OpenFL 3.6.1 (Legacy or Next) is still fully supported. The breaking changes when upgrading to OpenFL 8.0.0 and Lime 6.3.0 are as follows:

--- a/documentation/04_community/12-flixel-tools.html.md
+++ b/documentation/04_community/12-flixel-tools.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Flixel Tools"
-```
-
+---
 To make HaxeFlixel development easier, a set of command line tools has been developed with [Haxe](http://haxe.org) and [Neko](http://nekovm.org). With it you can easily create our demo projects, templates and more. Just like HaxeFlixel it is an open-source tool and additions/improvements from the community are welcome at the [flixel-tools GitHub repository](https://github.com/HaxeFlixel/flixel-tools).
 
 ## Installation

--- a/documentation/04_community/13-install-development-flixel.html.md
+++ b/documentation/04_community/13-install-development-flixel.html.md
@@ -1,7 +1,6 @@
-```
+---
 title: "Install development Flixel"
-```
-
+---
 Developers may want to contribute and / or stay updated with the bleeding edge code of HaxeFlixel. Like any development code we caution the use of it as it may not have the same amount of testing as the stable version.
 
 All new development is done on the dev branches of [HaxeFlixel's GitHub repositories](https://github.com/HaxeFlixel).


### PR DESCRIPTION
the flixel-docs half for https://github.com/HaxeFlixel/haxeflixel.com/issues/225 and https://github.com/HaxeFlixel/haxeflixel.com/issues/223

converts backticks in the frontmatter of the markdown files into dashes, for better compatibility with other markdown / static site generators