### PR TITLE
Update 01-install-haxeflixel.md

### DIFF
--- a/documentation/00_getting_started/01-install-haxeflixel.md
+++ b/documentation/00_getting_started/01-install-haxeflixel.md
@@ -5,8 +5,6 @@ title: "Install HaxeFlixel"
 To install the latest stable version of HaxeFlixel, open a command prompt and run the following [Haxelib](http://lib.haxe.org/) commands:
 
 ``` bash
-haxelib install lime
-haxelib install openfl
 haxelib install flixel
 ```
 

--- a/documentation/00_getting_started/01-install-haxeflixel.md
+++ b/documentation/00_getting_started/01-install-haxeflixel.md
@@ -2,10 +2,17 @@
 title: "Install HaxeFlixel"
 ---
 
-To install the latest stable version of HaxeFlixel, open a command prompt and run the following [Haxelib](http://lib.haxe.org/) commands:
+To install the latest stable version of HaxeFlixel, open a command prompt and run the following [Haxelib](http://lib.haxe.org/) commands. This will also install dependencies Lime and OpenFL:
 
 ``` bash
 haxelib install flixel
+```
+
+However, if you are using HaxeFlixel from 5.9.0 and below, you will have install Lime and OpenFL explicitly:
+
+```bash
+haxelib install openfl
+haxelib install lime
 ```
 
 After the installation is complete, you can compile games to HTML5, Flash and Neko out of the box.


### PR DESCRIPTION
on version flixel 6.0.0 or maybe greater, i found that flixel can now install dependency lime and openfl so i created this pull request to remove `haxelib install lime` and `haxelib install openfl` since flixel now can install lime and openfl too

like this:
![image](https://github.com/user-attachments/assets/48fa1a1d-d633-4cdb-b730-df6cb1b70d18)
