### PR TITLE
Update 04-3-groundwork.html.md

### DIFF
--- a/documentation/01_tutorial/04-3-groundwork.html.md
+++ b/documentation/01_tutorial/04-3-groundwork.html.md
@@ -54,7 +54,7 @@ First up, let's create a simple menu. Eventually, we'll want a fancy `MenuState`
 	```haxe
 	function clickPlay()
 	{
-		FlxG.switchState(new PlayState());
+		FlxG.switchState(PlayState.new);
 	}
 	```
 	(`import flixel.FlxG;`)


### PR DESCRIPTION
FlxG.switchState(new PlayState()); is now deprecated.
Apparently it caused problems because things were initalized in the constructor while the old state was still active.